### PR TITLE
feat: Support Elixir 1.18

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+direnv_load mise direnv exec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,31 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  build-otp-23:
-    name: Build and test on OTP 23
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        elixir_version:
-          - "1.10"
-          - "1.11"
-          - "1.12"
-          - "1.13"
-    steps:
-      - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
-        with:
-          elixir-version: ${{ matrix.elixir_version }}
-          otp-version: "23"
-      - uses: actions/cache@v3
-        with:
-          path: deps
-          key: 23-${{ matrix.elixir_version }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            23-${{ matrix.elixir_version }}-
-            23-
-      - run: mix deps.get
-      - run: mix test
   build-otp-24:
     name: Build and test on OTP 24
     runs-on: ubuntu-20.04
@@ -92,6 +67,7 @@ jobs:
         elixir_version:
           - "1.14"
           - "1.15"
+          - "1.16"
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -105,5 +81,29 @@ jobs:
           restore-keys: |
             26-${{ matrix.elixir_version }}-
             26-
+      - run: mix deps.get
+      - run: mix test
+  build-otp-27:
+    name: Build and test on OTP 27
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        elixir_version:
+          - "1.16"
+          - "1.17"
+          - "1.18"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir_version }}
+          otp-version: "27"
+      - uses: actions/cache@v3
+        with:
+          path: deps
+          key: 27-${{ matrix.elixir_version }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            27-${{ matrix.elixir_version }}-
+            27-
       - run: mix deps.get
       - run: mix test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,6 @@ jobs:
     strategy:
       matrix:
         elixir_version:
-          - "1.16"
           - "1.17"
           - "1.18"
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.14"
-          otp-version: "24"
+          elixir-version: "1.18"
+          otp-version: "27"
       - run: mix deps.get
       - run: mix test
       - run: mix hex.publish --yes

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+elixir = "1.17.3-otp-27"
+erlang = "27.2.1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-elixir = "1.17.3-otp-27"
+elixir = "1.18.2-otp-27"
 erlang = "27.2.1"

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule AssertMatch.MixProject do
       app: :assert_match,
       description:
         "Leverages pattern matching & pipeline in Elixir tests by pipe-friendly `assert_match/2`",
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.10",
       package: package(),
       deps: [{:ex_doc, "~> 0.27", only: :dev, runtime: false}]

--- a/test/assert_match_test.exs
+++ b/test/assert_match_test.exs
@@ -18,7 +18,7 @@ defmodule AssertMatchTest do
     end
 
     test "should work with regex" do
-      assert_match("prefix match", ~R/prefix/)
+      assert_match("prefix match", ~r/prefix/)
       assert_match("prefix match", ~r/#{"prefix"}/)
     end
 

--- a/test/assert_match_test.exs
+++ b/test/assert_match_test.exs
@@ -27,6 +27,7 @@ defmodule AssertMatchTest do
       assert_match("prefix match", "prefix" <> _)
       assert_match(%{key: 1}, %{})
       assert_match(%{key: 1}, %{key: _})
+      assert_match(%{key: 1}, map when is_map_key(map, :key))
       assert_match([1, 2], [_ | _])
     end
 

--- a/test/assert_match_test.exs
+++ b/test/assert_match_test.exs
@@ -27,8 +27,14 @@ defmodule AssertMatchTest do
       assert_match("prefix match", "prefix" <> _)
       assert_match(%{key: 1}, %{})
       assert_match(%{key: 1}, %{key: _})
-      assert_match(%{key: 1}, map when is_map_key(map, :key))
       assert_match([1, 2], [_ | _])
+    end
+
+    test "should work with guards" do
+      assert_match(%{key: 1}, map when is_map_key(map, :key))
+
+      # guard works with assert_match/2 but has limitation: bindings inside patterns cannot be used from outside
+      assert_match(%{key: 1}, %{key: _value} = map when not is_map_key(map, :nonkey))
     end
 
     test "should work with incomplete struct patterns" do


### PR DESCRIPTION
- **test: guard in assert_match/2**
- **chore: use mise and direnv for development**
- **chore: Elixir 1.18 drops ~R//**
- **ci: drop Erlang 23, support 27**
